### PR TITLE
Jack/bugfixes

### DIFF
--- a/extension/src/api/AzureDevopsClient.ts
+++ b/extension/src/api/AzureDevopsClient.ts
@@ -21,8 +21,7 @@ export async function getDashboardEnvironmentPipeline(projectName: string): Prom
 
     const environmentPipelines: IEnvironmentPipelines[] = []
     for (const environment of environments) {
-        const deployments = await taskAgentClient.getEnvironmentDeploymentExecutionRecords(projectName, environment.id)
-
+        const deployments = await taskAgentClient.getEnvironmentDeploymentExecutionRecords(projectName, environment.id, undefined, 1000)
         const environmentPipeline: IEnvironmentPipelines = {
             name: environment.name,
             pipeline: {},

--- a/extension/src/components/ListViewDeploymentsTable.tsx
+++ b/extension/src/components/ListViewDeploymentsTable.tsx
@@ -3,10 +3,10 @@ import { Link } from 'azure-devops-ui/Link'
 import React from 'react'
 import { Status, StatusSize } from 'azure-devops-ui/Status'
 import { AgoFormat } from 'azure-devops-ui/Utilities/Date'
-import { Ago } from 'azure-devops-ui/Ago'
 import { getStatusIndicatorData } from '../utilities'
 import { IDashboardEnvironmentColumn, IEnvironmentInstance, IPipelineInstance } from '../types'
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider'
+import { SafeAgo } from './SafeAgo'
 
 export const ListViewDeploymentsTable = (props: { environments: IEnvironmentInstance[]; pipelines: IPipelineInstance[] }): JSX.Element => {
     const { environments, pipelines } = props
@@ -63,7 +63,7 @@ export const ListViewDeploymentsTable = (props: { environments: IEnvironmentInst
                             </Link>
                             <div className="finish-date">
                                 {tableItem.environments[tableColumn.id].finishTime && (
-                                    <Ago date={tableItem.environments[tableColumn.id].finishTime} format={AgoFormat.Extended} />
+                                    <SafeAgo date={tableItem.environments[tableColumn.id].finishTime} format={AgoFormat.Extended} />
                                 )}
                             </div>
                         </div>

--- a/extension/src/components/SafeAgo.tsx
+++ b/extension/src/components/SafeAgo.tsx
@@ -1,0 +1,14 @@
+import { Ago, IAgoProps } from "azure-devops-ui/Ago"
+import React from "react"
+
+// Errors thrown by this component are a bit random and very annoying. 
+export const SafeAgo = (props: IAgoProps) => {
+    try {
+        return (<Ago {...props} />)
+    }
+    catch(error){
+        console.warn("Ago component threw an error.")
+        console.warn(error)
+        return <></>
+    }
+}

--- a/extension/src/components/TreeViewDeploymentsTable.tsx
+++ b/extension/src/components/TreeViewDeploymentsTable.tsx
@@ -9,10 +9,10 @@ import { SimpleTableCell } from 'azure-devops-ui/Table'
 import { Status, StatusSize } from 'azure-devops-ui/Status'
 import { getStatusIndicatorData } from '../utilities'
 import { Link } from 'azure-devops-ui/Link'
-import { Ago } from 'azure-devops-ui/Ago'
 import { useState, useEffect } from 'react'
 import { ITreeItemProvider } from 'azure-devops-ui/Utilities/TreeItemProvider'
 import { AgoFormat } from 'azure-devops-ui/Utilities/Date'
+import { SafeAgo } from './SafeAgo'
 
 export const TreeViewDeploymentsTable = (props: { environments: IEnvironmentInstance[]; pipelines: IPipelineInstance[] }): JSX.Element => {
     const { environments, pipelines } = props
@@ -134,7 +134,9 @@ export const TreeViewDeploymentsTable = (props: { environments: IEnvironmentInst
                             {pipeline.environments[treeColumn!.name!].value}
                         </Link>
                         <div className="finish-date">
-                            <Ago date={pipeline.environments[treeColumn!.id!].finishTime} format={AgoFormat.Extended} />
+                            {pipeline.environments[treeColumn!.id!].finishTime && (
+                                <SafeAgo date={pipeline.environments[treeColumn!.id!].finishTime} format={AgoFormat.Extended} />
+                            )}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Two small fixes: 

🐞 Organisations with lots of pipelines are missing pipelines from the dashboard. 
- The `getEnvironmentDeploymentExecutionRecords` appears to return only 25 deployments at a time. 
- This is increased to 1000, which may have performance impact, but will eventually load. 
- Better filtering and ability for the user to select which pipelines appear will mitigate the load time problem but is outside the scope of this PR. 

🐛  Occasional crashes from the Ago component. 
- The tree view sometimes crashes with an error that undefined cannot be parsed as a date
- Added a wrapper component to ago to prevent crashes and just log warnings. This will also help with testing. 
- Added a check in the treeview component for cases when the finish time is undefined. 