### PR TITLE
Add a button to download diagnostic data. 

### DIFF
--- a/extension/src/components/SafeAgo.tsx
+++ b/extension/src/components/SafeAgo.tsx
@@ -1,13 +1,12 @@
-import { Ago, IAgoProps } from "azure-devops-ui/Ago"
-import React from "react"
+import { Ago, IAgoProps } from 'azure-devops-ui/Ago'
+import React from 'react'
 
-// Errors thrown by this component are a bit random and very annoying. 
+// Errors thrown by this component are a bit random and very annoying.
 export const SafeAgo = (props: IAgoProps) => {
     try {
-        return (<Ago {...props} />)
-    }
-    catch(error){
-        console.warn("Ago component threw an error.")
+        return <Ago {...props} />
+    } catch (error) {
+        console.warn('Ago component threw an error.')
         console.warn(error)
         return <></>
     }

--- a/extension/src/dashboard/Dashboard.tsx
+++ b/extension/src/dashboard/Dashboard.tsx
@@ -3,41 +3,24 @@ import * as ReactDOM from 'react-dom'
 import { InitTelemetry } from '../telemetry/applicationInsights'
 import { initAzureDevOpsSdk } from '../api/AzureDevOpsSdkManager'
 import { getDashboardEnvironmentPipeline } from '../api/AzureDevopsClient'
-import { ExtensionDataKeys, IDashboardMainState, IEnvironmentInstance } from '../types'
+import { ExtensionDataKeys, IDashboardContentState, IEnvironmentInstance } from '../types'
 import { DashboardContent } from './DashboardContent'
 import { merge } from '../utilities'
 import './Dashboard.scss'
-
-export class Dashboard extends React.Component<{}, IDashboardMainState> {
-    constructor(props: {}) {
-        super(props)
-
-        this.state = {
-            environments: [],
-            pipelines: [],
-            isLoading: true,
-        }
-    }
-
-    public async componentDidMount() {
-        const projectInfo = await initAzureDevOpsSdk()
-
-        const { environments, pipelines } = await getDashboardEnvironmentPipeline(projectInfo.name)
-
-        const sortedEnvironments =
-            (await projectInfo.extensionDataManager.getValue<IEnvironmentInstance[]>(ExtensionDataKeys.Environments)) ?? []
-
-        this.setState({
-            environments: merge(environments, sortedEnvironments) ?? environments,
-            pipelines: pipelines,
-            projectInfo: projectInfo,
-            isLoading: false,
-        })
-    }
-
-    public render(): JSX.Element {
-        return <DashboardContent {...this.state}></DashboardContent>
-    }
+const Dashboard = () => {
+    const [state, setState] = React.useState<IDashboardContentState>({
+        environments: [],
+        pipelines: [],
+        isLoading: true,
+    })
+    React.useEffect(() => {
+        load()
+            .then((data) => setState(data))
+            .catch((err) => {
+                throw err
+            })
+    })
+    return <DashboardContent state={state}></DashboardContent>
 }
 
 // todo: add user settings for this.
@@ -46,3 +29,19 @@ const enableTelemetry = false
 InitTelemetry(enableTelemetry)
 
 ReactDOM.render(<Dashboard />, document.getElementById('root'))
+
+async function load(): Promise<IDashboardContentState> {
+    const projectInfo = await initAzureDevOpsSdk()
+
+    const { environments, pipelines } = await getDashboardEnvironmentPipeline(projectInfo.name)
+
+    const sortedEnvironments =
+        (await projectInfo.extensionDataManager.getValue<IEnvironmentInstance[]>(ExtensionDataKeys.Environments)) ?? []
+
+    return {
+        environments: merge(environments, sortedEnvironments) ?? environments,
+        pipelines: pipelines,
+        projectInfo: projectInfo,
+        isLoading: false,
+    }
+}

--- a/extension/src/dashboard/DashboardContent.test.tsx
+++ b/extension/src/dashboard/DashboardContent.test.tsx
@@ -3,10 +3,11 @@ import * as React from 'react'
 import '@testing-library/jest-dom'
 import '@testing-library/jest-dom/jest-globals'
 import { data } from './DashboardContent.test.data'
-import { DashboardContent, DashboardContentProps } from './DashboardContent'
+import { DashboardContent } from './DashboardContent'
+import { IDashboardContentState } from '../types'
 
 test('Render and check layout', async () => {
-    render(<DashboardContent {...(data as unknown as DashboardContentProps)} />)
+    render(<DashboardContent state={data as unknown as IDashboardContentState} />)
 
     await screen.findByRole('heading')
 
@@ -17,7 +18,7 @@ test('Render and check layout', async () => {
 })
 
 test('Check all pipelines are included', async () => {
-    render(<DashboardContent {...(data as unknown as DashboardContentProps)} />)
+    render(<DashboardContent state={data as unknown as IDashboardContentState} />)
 
     const rows = screen.getAllByRole('row')
     expect(rows).toHaveLength(8) // includes header
@@ -33,7 +34,7 @@ test('Check all pipelines are included', async () => {
 })
 
 test('Check all environments are included', async () => {
-    render(<DashboardContent {...(data as unknown as DashboardContentProps)} />)
+    render(<DashboardContent state={data as unknown as IDashboardContentState} />)
     for (const env of data.environments) {
         const column = screen.getByText(env.name)
         expect(column).toBeInTheDocument()

--- a/extension/src/dashboard/DashboardContent.tsx
+++ b/extension/src/dashboard/DashboardContent.tsx
@@ -5,7 +5,7 @@ import { Spinner, SpinnerSize } from 'azure-devops-ui/Spinner'
 import React, { useEffect, useState } from 'react'
 import { Link } from 'azure-devops-ui/Link'
 import { Button } from 'azure-devops-ui/Button'
-import { IEnvironmentInstance, IPipelineInstance, IDevOpsProjectInfo } from '../types'
+import { IDashboardContentState } from '../types'
 import { TreeViewDeploymentsTable } from '../components/TreeViewDeploymentsTable'
 import { DropdownSelection } from 'azure-devops-ui/Utilities/DropdownSelection'
 import { ListViewDeploymentsTable } from '../components/ListViewDeploymentsTable'
@@ -13,10 +13,7 @@ import { HeaderCommandBar, IHeaderCommandBarItem } from 'azure-devops-ui/HeaderC
 import { IMenuItem } from 'azure-devops-ui/Menu'
 
 export type DashboardContentProps = {
-    environments: IEnvironmentInstance[]
-    pipelines: IPipelineInstance[]
-    projectInfo?: IDevOpsProjectInfo
-    isLoading: boolean
+    state: IDashboardContentState
 }
 
 enum ViewType {
@@ -25,7 +22,9 @@ enum ViewType {
 }
 
 export const DashboardContent = (props: DashboardContentProps) => {
-    const { environments, pipelines, projectInfo, isLoading } = props
+    const {
+        state: { environments, pipelines, projectInfo, isLoading },
+    } = props
 
     const viewSelection = new DropdownSelection()
     const [viewType, setViewType] = useState(ViewType.List.toString())

--- a/extension/src/diagnostics.ts
+++ b/extension/src/diagnostics.ts
@@ -1,0 +1,59 @@
+import { EnvironmentDeploymentExecutionRecord, TaskAgentRestClient } from 'azure-devops-extension-api/TaskAgent'
+import { getDashboardEnvironmentPipeline } from './api/AzureDevopsClient'
+import { initAzureDevOpsSdk } from './api/AzureDevOpsSdkManager'
+import { ExtensionDataKeys, IEnvironmentInstance } from './types'
+import { PipelinesRestClient } from 'azure-devops-extension-api/Pipelines/PipelinesClient'
+import { getClient } from 'azure-devops-extension-api'
+
+export const diagnostics = async () => {
+    // Get browser data.
+    const browser = {
+        userAgent: navigator.userAgent,
+        language: navigator.language,
+        cookiesEnabled: navigator.cookieEnabled,
+        online: navigator.onLine,
+    }
+
+    // Get the same models as the dashboard.
+    const projectInfo = await initAzureDevOpsSdk()
+    const { environments, pipelines } = await getDashboardEnvironmentPipeline(projectInfo.name)
+    const sortedEnvironments =
+        (await projectInfo.extensionDataManager.getValue<IEnvironmentInstance[]>(ExtensionDataKeys.Environments)) ?? []
+
+    // Get raw data for comparison to dashboard model.
+    const taskAgentClient = getClient(TaskAgentRestClient)
+    const pipelinesClient = getClient(PipelinesRestClient)
+
+    const [rawPipelines, rawEnvironments] = await Promise.all([
+        pipelinesClient.listPipelines(projectInfo.name, 'name asc', 1000),
+        taskAgentClient.getEnvironments(projectInfo.name),
+    ])
+
+    let rawDeployments: EnvironmentDeploymentExecutionRecord[] = []
+    for (const environment of rawEnvironments) {
+        const deployments = await taskAgentClient.getEnvironmentDeploymentExecutionRecords(
+            projectInfo.name,
+            environment.id,
+            undefined,
+            1000
+        )
+        rawDeployments = [...rawDeployments, ...deployments]
+    }
+
+    const rawData = {
+        environments: rawEnvironments,
+        pipelines: rawPipelines,
+        deployments: rawDeployments,
+    }
+
+    const data = {
+        projectInfo,
+        environments,
+        pipelines,
+        sortedEnvironments,
+        browser,
+        raw: rawData,
+    }
+
+    return data
+}

--- a/extension/src/settings/SettingsContent.tsx
+++ b/extension/src/settings/SettingsContent.tsx
@@ -9,16 +9,16 @@ import { Button } from 'azure-devops-ui/Button'
 import { Page } from 'azure-devops-ui/Page'
 import { HeaderCommandBar, IHeaderCommandBarItem } from 'azure-devops-ui/HeaderCommandBar'
 import { ListDragDropBehavior, ListDragImage } from 'azure-devops-ui/List'
-import { IEnvironmentInstance, ISettingsContentState } from '../types'
+import { IEnvironmentInstance, ISettingsContentProps } from '../types'
 import './Settings.scss'
 
-export const SettingsContent = (props: { state: ISettingsContentState }) => {
-    const { state } = props
+export const SettingsContent = (props: ISettingsContentProps) => {
+    const { state, onResetToDefaultSortOrder, onSaveCustomSortOrder, onTableRowDrop } = props
     const environmentsCardHeaderCommandBarItems: IHeaderCommandBarItem[] = [
         {
             id: 'reset-sort-order-settings',
             text: 'Reset to default',
-            onActivate: state.onResetToDefaultSortOrder,
+            onActivate: onResetToDefaultSortOrder,
             iconProps: {
                 iconName: 'Undo',
             },
@@ -27,7 +27,7 @@ export const SettingsContent = (props: { state: ISettingsContentState }) => {
             id: 'sort-order-save',
             text: 'Save',
             isPrimary: true,
-            onActivate: state.onSaveCustomSortOrder,
+            onActivate: onSaveCustomSortOrder,
             iconProps: {
                 iconName: 'Save',
             },
@@ -52,7 +52,7 @@ export const SettingsContent = (props: { state: ISettingsContentState }) => {
         id: 'environment-dragndrop-behavior',
         type: 'IEnvironmentInstance',
         renderDragImage: (event) => <ListDragImage text={event.detail.dataTransfer.data.name ?? 'UNKNOWN ENVIRONMENT'} />,
-        onDrop: state.onTableRowDrop,
+        onDrop: onTableRowDrop,
     })
 
     function renderGripper(_: number, left: boolean) {

--- a/extension/src/settings/SettingsContent.tsx
+++ b/extension/src/settings/SettingsContent.tsx
@@ -11,6 +11,8 @@ import { HeaderCommandBar, IHeaderCommandBarItem } from 'azure-devops-ui/HeaderC
 import { ListDragDropBehavior, ListDragImage } from 'azure-devops-ui/List'
 import { IEnvironmentInstance, ISettingsContentProps } from '../types'
 import './Settings.scss'
+import { downloadJson } from '../utilities'
+import { diagnostics } from '../diagnostics'
 
 export const SettingsContent = (props: ISettingsContentProps) => {
     const { state, onResetToDefaultSortOrder, onSaveCustomSortOrder, onTableRowDrop } = props
@@ -45,7 +47,25 @@ export const SettingsContent = (props: ISettingsContentProps) => {
             target: '_top',
             text: 'View dashboard',
         },
+        {
+            iconProps: { iconName: 'Download' },
+            id: 'diagnostic-dump',
+            tooltipProps: { text: 'Export a diagnostic package' },
+            isPrimary: false,
+            important: false,
+            // href: state.projectInfo?.deploymentDashboardUri,
+            target: '_top',
+            text: 'Export Diagnostics',
+            onActivate: () => {
+                downloadDiagnosticData()
+            },
+        },
     ]
+
+    const downloadDiagnosticData = async () => {
+        const data = await diagnostics()
+        downloadJson(data, `dashboard_diagnostics_${new Date().getTime()}.json`)
+    }
 
     const dragDropBehavior = new ListDragDropBehavior<IEnvironmentInstance>({
         allowedTypes: ['IEnvironmentInstance'],

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -77,7 +77,7 @@ export type IDeploymentTableItem = {
     name: string
 }
 
-export interface IDashboardMainState {
+export interface IDashboardContentState {
     environments: IEnvironmentInstance[]
     pipelines: IPipelineInstance[]
     isLoading: boolean
@@ -95,15 +95,19 @@ export enum ExtensionDataKeys {
     Environments = 'Environments',
 }
 
+export interface ISettingsContentProps {
+    state: ISettingsContentState
+    onTableRowDrop?: (event: BoltListDragEvent<HTMLElement, IEnvironmentInstance>, dropData: IListDropData) => void
+    onSaveCustomSortOrder: () => void
+    onResetToDefaultSortOrder: () => void
+}
+
 export interface ISettingsContentState {
     columns: ITableColumn<IEnvironmentInstance>[]
     environments: ArrayItemProvider<IEnvironmentInstance>
     projectInfo?: IDevOpsProjectInfo
     organisation?: string
     isLoading: boolean
-    onTableRowDrop?: (event: BoltListDragEvent<HTMLElement, IEnvironmentInstance>, dropData: IListDropData) => void
-    onSaveCustomSortOrder: () => void
-    onResetToDefaultSortOrder: () => void
 }
 
 /**

--- a/extension/src/utilities.ts
+++ b/extension/src/utilities.ts
@@ -114,3 +114,17 @@ export function getStatusIndicatorData(status: number): IStatusIndicatorData {
 
     return indicatorData
 }
+
+/**
+ * Starts a file download containing the object as json.
+ **/
+export function downloadJson(data: object, fileName: string) {
+    const jsonString = JSON.stringify(data, null, 2)
+    const blob = new Blob([jsonString], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    link.click()
+    URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
**Diagnostics**
Adds a button to download data we can use to diagnose bugs. 

This way, a bug report can be submitted with the data that was used to render the dashboard, and the user can decide for themselves if they want to share this data, or santitize it or share only part. 

The button is on the settings page. 
<img width="261" alt="image" src="https://github.com/user-attachments/assets/954b5a47-a7b9-4706-924f-59f30459d90c">


The data included is: 
- project info
- models used in the dashboard views
- raw pipeline, environment, and deployment data from the Azure Devops API
- browser info

**Bug Fix**
- Added a wrapper around the Ago component to catch date time parse issues that crash the dashboar.d 

**Refactoring**
- Refactored class based components to be functional components. 
